### PR TITLE
修改 PutController 的使用姿势

### DIFF
--- a/base/lib/src/storage/methods/put/by_part/complete_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/complete_parts_task.dart
@@ -16,7 +16,8 @@ class CompletePartsTask extends RequestTask<PutResponse> {
     @required this.parts,
     @required this.host,
     this.key,
-  });
+    RequestTaskController controller,
+  }) : super(controller: controller);
 
   @override
   Future<PutResponse> createTask() async {

--- a/base/lib/src/storage/methods/put/by_part/init_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/init_parts_task.dart
@@ -42,7 +42,8 @@ class InitPartsTask extends RequestTask<InitParts> with CacheMixin<InitParts> {
     @required this.bucket,
     @required this.token,
     this.key,
-  });
+    RequestTaskController controller,
+  }) : super(controller: controller);
 
   static String getCacheKey(String path, int length, String key) {
     return 'qiniu_dart_sdk_init_parts_task_${path}_key_${key}_size_$length';

--- a/base/lib/src/storage/methods/put/by_part/put_by_part_options.dart
+++ b/base/lib/src/storage/methods/put/by_part/put_by_part_options.dart
@@ -1,3 +1,5 @@
+import '../put_controller.dart';
+
 class PutByPartOptions {
   /// 资源名
   /// 如果不传则后端自动生成
@@ -11,9 +13,13 @@ class PutByPartOptions {
 
   final int maxPartsRequestNumber;
 
+  /// 控制器
+  final PutController controller;
+
   PutByPartOptions({
     this.key,
     this.partSize,
     this.maxPartsRequestNumber,
+    this.controller,
   });
 }

--- a/base/lib/src/storage/methods/put/by_single/put_by_single_options.dart
+++ b/base/lib/src/storage/methods/put/by_single/put_by_single_options.dart
@@ -1,7 +1,13 @@
+import '../put_controller.dart';
+
 class PutBySingleOptions {
   /// 资源名
+  ///
   /// 如果不传则后端自动生成
   final String key;
 
-  PutBySingleOptions({this.key});
+  /// 控制器
+  final PutController controller;
+
+  PutBySingleOptions({this.key, this.controller});
 }

--- a/base/lib/src/storage/methods/put/by_single/put_by_single_task.dart
+++ b/base/lib/src/storage/methods/put/by_single/put_by_single_task.dart
@@ -22,8 +22,10 @@ class PutBySingleTask extends RequestTask<PutResponse> {
     @required this.file,
     @required this.token,
     this.key,
+    RequestTaskController controller,
   })  : assert(file != null),
-        assert(token != null);
+        assert(token != null),
+        super(controller: controller);
 
   @override
   Future<PutResponse> createTask() async {

--- a/base/lib/src/storage/methods/put/put_controller.dart
+++ b/base/lib/src/storage/methods/put/put_controller.dart
@@ -1,22 +1,3 @@
-import '../../task/request_task.dart'
-    show RequestTaskProgressListener, RequestTaskStatusListener, RequestTask;
-import 'put_response.dart';
+import '../../task/request_task.dart';
 
-class PutController {
-  final RequestTask<PutResponse> _task;
-  const PutController(this._task);
-
-  Future<PutResponse> get future => _task.future;
-
-  void Function() addProgressListener(RequestTaskProgressListener listener) {
-    return _task.addProgressListener(listener);
-  }
-
-  void Function() addStatusListener(RequestTaskStatusListener listener) {
-    return _task.addStatusListener(listener);
-  }
-
-  void cancel() {
-    _task.cancel();
-  }
-}
+class PutController extends RequestTaskController {}

--- a/base/lib/src/storage/methods/put/put_options.dart
+++ b/base/lib/src/storage/methods/put/put_options.dart
@@ -1,5 +1,8 @@
+import 'put_controller.dart';
+
 class PutOptions {
   /// 资源名
+  ///
   /// 如果不传则后端自动生成
   final String key;
 
@@ -12,10 +15,14 @@ class PutOptions {
   /// 并发上传的队列长度，默认值为 5
   final int maxPartsRequestNumber;
 
+  /// 控制器
+  final PutController controller;
+
   PutOptions({
     this.key,
     this.forceBySingle,
     this.partSize,
     this.maxPartsRequestNumber,
+    this.controller,
   });
 }

--- a/base/lib/src/storage/methods/put/put_task.dart
+++ b/base/lib/src/storage/methods/put/put_task.dart
@@ -3,11 +3,12 @@ import 'dart:io';
 import 'package:meta/meta.dart';
 
 import '../../task/request_task.dart';
+import '../../task/task.dart';
 import 'by_part/put_parts_task.dart';
 import 'by_single/put_by_single_task.dart';
 import 'put_response.dart';
 
-class PutTask extends RequestTask<PutResponse> {
+class PutTask extends Task<PutResponse> {
   final File file;
   final String token;
 
@@ -17,6 +18,7 @@ class PutTask extends RequestTask<PutResponse> {
   final int maxPartsRequestNumber;
 
   final String key;
+  final RequestTaskController controller;
 
   PutTask({
     @required this.file,
@@ -25,6 +27,7 @@ class PutTask extends RequestTask<PutResponse> {
     this.partSize,
     this.maxPartsRequestNumber,
     this.key,
+    this.controller,
   })  : assert(file != null),
         assert(token != null);
 
@@ -45,18 +48,18 @@ class PutTask extends RequestTask<PutResponse> {
         key: key,
         maxPartsRequestNumber: maxPartsRequestNumber,
         partSize: partSize,
+        controller: controller,
       );
     } else {
       task = PutBySingleTask(
         file: file,
         token: token,
         key: key,
+        controller: controller,
       );
     }
 
-    task.addProgressListener(notifyProgressListeners);
-
-    manager.addTask(task);
+    manager.addRequestTask(task);
     return task.future;
   }
 }

--- a/base/lib/src/storage/methods/put/put_task.dart
+++ b/base/lib/src/storage/methods/put/put_task.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:meta/meta.dart';
 
+import '../../config/config.dart';
 import '../../task/request_task.dart';
 import '../../task/task.dart';
 import 'by_part/put_parts_task.dart';
@@ -19,10 +20,12 @@ class PutTask extends Task<PutResponse> {
 
   final String key;
   final RequestTaskController controller;
+  final HostProvider hostProvider;
 
   PutTask({
     @required this.file,
     @required this.token,
+    @required this.hostProvider,
     this.forceBySingle,
     this.partSize,
     this.maxPartsRequestNumber,
@@ -38,18 +41,20 @@ class PutTask extends Task<PutResponse> {
   @override
   Future<PutResponse> createTask() async {
     final fileSize = await file.length();
-    RequestTask<PutResponse> task;
+    Task<PutResponse> task;
 
     /// 文件尺寸大于设置的数值时使用分片上传
     if (usePart(fileSize)) {
-      task = PutByPartTask(
+      final task = PutByPartTask(
         file: file,
         token: token,
         key: key,
         maxPartsRequestNumber: maxPartsRequestNumber,
         partSize: partSize,
         controller: controller,
+        hostProvider: null,
       );
+      manager.addTask(task);
     } else {
       task = PutBySingleTask(
         file: file,
@@ -57,9 +62,9 @@ class PutTask extends Task<PutResponse> {
         key: key,
         controller: controller,
       );
+      manager.addRequestTask(task as RequestTask<PutResponse>);
     }
 
-    manager.addRequestTask(task);
     return task.future;
   }
 }

--- a/base/lib/src/storage/storage.dart
+++ b/base/lib/src/storage/storage.dart
@@ -34,6 +34,7 @@ class Storage {
       maxPartsRequestNumber: options?.maxPartsRequestNumber ?? 5,
       key: options?.key,
       controller: options?.controller,
+      hostProvider: config.hostProvider,
     );
 
     taskManager.addTask(task);
@@ -73,9 +74,10 @@ class Storage {
       partSize: options?.partSize ?? 4,
       maxPartsRequestNumber: options?.maxPartsRequestNumber ?? 5,
       controller: options?.controller,
+      hostProvider: config.hostProvider,
     );
 
-    taskManager.addRequestTask(task);
+    taskManager.addTask(task);
 
     return task.future;
   }

--- a/base/lib/src/storage/storage.dart
+++ b/base/lib/src/storage/storage.dart
@@ -14,14 +14,14 @@ export 'task/task.dart';
 /// 客户端
 class Storage {
   Config config;
-  RequestTaskManager taskManager;
+  TaskManager taskManager;
 
   Storage({Config config}) {
     this.config = config ?? Config();
-    taskManager = RequestTaskManager(config: this.config);
+    taskManager = TaskManager(config: this.config);
   }
 
-  PutController putFile(
+  Future<PutResponse> putFile(
     File file,
     String token, {
     PutOptions options,
@@ -33,14 +33,15 @@ class Storage {
       partSize: options?.partSize ?? 4,
       maxPartsRequestNumber: options?.maxPartsRequestNumber ?? 5,
       key: options?.key,
+      controller: options?.controller,
     );
 
     taskManager.addTask(task);
-    return PutController(task);
+    return task.future;
   }
 
   /// 单文件上传
-  PutController putFileBySingle(
+  Future<PutResponse> putFileBySingle(
     File file,
     String token, {
     PutBySingleOptions options,
@@ -49,16 +50,18 @@ class Storage {
       file: file,
       token: token,
       key: options?.key,
+      controller: options?.controller,
     );
 
-    taskManager.addTask(task);
-    return PutController(task);
+    taskManager.addRequestTask(task);
+
+    return task.future;
   }
 
   /// 分片上传
   /// FIXME: 应该使用 [listParts](https://developer.qiniu.com/kodo/api/6858/listparts) 重写现有缓存机制
   /// FIXME: 取消时应该实现 [abortMultipartUpload](https://developer.qiniu.com/kodo/api/6367/abort-multipart-upload) 接口
-  PutController putFileByPart(
+  Future<PutResponse> putFileByPart(
     File file,
     String token, {
     PutByPartOptions options,
@@ -69,9 +72,11 @@ class Storage {
       key: options?.key,
       partSize: options?.partSize ?? 4,
       maxPartsRequestNumber: options?.maxPartsRequestNumber ?? 5,
+      controller: options?.controller,
     );
 
-    taskManager.addTask(task);
-    return PutController(task);
+    taskManager.addRequestTask(task);
+
+    return task.future;
   }
 }

--- a/base/lib/src/storage/task/request_task_controller.dart
+++ b/base/lib/src/storage/task/request_task_controller.dart
@@ -1,0 +1,81 @@
+part of 'request_task.dart';
+
+class RequestTaskController
+    with RequestTaskProgressListenersMixin, RequestTaskStatusListenersMixin {
+  final CancelToken cancelToken = CancelToken();
+
+  void cancel() {
+    if (cancelToken.isCancelled) {
+      throw UnsupportedError('$this has been canceled.');
+    }
+
+    cancelToken.cancel();
+  }
+}
+
+typedef RequestTaskProgressListener = void Function(int sent, int total);
+
+/// 请求进度。
+///
+/// 使用 client 发出去的请求才会触发，其他情况继承 RequestTask 的需要手动触发
+mixin RequestTaskProgressListenersMixin {
+  final List<RequestTaskProgressListener> progressListeners = [];
+
+  void Function() addProgressListener(RequestTaskProgressListener listener) {
+    progressListeners.add(listener);
+    return () => removeProgressListener(listener);
+  }
+
+  void removeProgressListener(RequestTaskProgressListener listener) {
+    progressListeners.remove(listener);
+  }
+
+  void notifyProgressListeners(int sent, int total) {
+    for (final listener in progressListeners) {
+      listener(sent, total);
+    }
+  }
+}
+
+enum RequestTaskStatus {
+  None,
+
+  /// 请求准备发出的时候触发
+  Request,
+
+  /// 请求完成后触发
+  Done,
+
+  /// 请求被取消后触发
+  Cancel,
+
+  /// 请求出错后触发
+  Error
+}
+
+typedef RequestTaskStatusListener = void Function(RequestTaskStatus status);
+
+/// 任务状态。
+///
+/// 自动触发(preStart, postReceive)
+mixin RequestTaskStatusListenersMixin {
+  RequestTaskStatus status = RequestTaskStatus.None;
+
+  final List<RequestTaskStatusListener> _statusListeners = [];
+
+  void Function() addStatusListener(RequestTaskStatusListener listener) {
+    _statusListeners.add(listener);
+    return () => removeStatusListener(listener);
+  }
+
+  void removeStatusListener(RequestTaskStatusListener listener) {
+    _statusListeners.remove(listener);
+  }
+
+  void notifyStatusListeners(RequestTaskStatus status) {
+    status = status;
+    for (final listener in _statusListeners) {
+      listener(status);
+    }
+  }
+}

--- a/base/lib/src/storage/task/task.dart
+++ b/base/lib/src/storage/task/task.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:qiniu_sdk_base/qiniu_sdk_base.dart';
 
 export 'request_task.dart';
 export 'task_manager.dart';
@@ -9,6 +10,8 @@ export 'task_manager.dart';
 ///
 /// 异步的任务，比如请求，批处理都可以继承这个类实现一个 Task
 abstract class Task<T> {
+  TaskManager manager;
+
   @protected
   Completer<T> completer = Completer();
 

--- a/base/test/storage_test.dart
+++ b/base/test/storage_test.dart
@@ -139,7 +139,7 @@ void main() {
   }, skip: !isSensitiveDataDefined);
 
   test('putFileByPart should works well while response 612.', () async {
-    final httpAdapterTest = HttpAdapterTest();
+    final httpAdapterTest = HttpAdapterTestWith612();
     final storage = Storage(config: Config(httpClientAdapter: httpAdapterTest));
 
     final response = await storage.putFileByPart(
@@ -158,7 +158,7 @@ void main() {
     final putController = PutController();
     final statusList = <RequestTaskStatus>[];
     putController.addStatusListener(statusList.add);
-    Future.delayed(Duration(milliseconds: 10), putController.cancel);
+    Future.delayed(Duration(milliseconds: 1), putController.cancel);
     final future = storage.putFileByPart(
       File('test_resource/test_for_put_parts.mp4'),
       token,
@@ -205,11 +205,7 @@ void main() {
     final response = await storage.putFileByPart(
       File('test_resource/test_for_put_parts.mp4'),
       token,
-      options: PutByPartOptions(
-        key: 'test_for_put_parts.mp4',
-        partSize: 1,
-        controller: putController,
-      ),
+      options: PutByPartOptions(key: 'test_for_put_parts.mp4', partSize: 1),
     );
 
     expect(response, isA<PutResponse>());
@@ -290,14 +286,18 @@ void main() {
     final response = await storage.putFileByPart(
       File('test_resource/test_for_put_parts.mp4'),
       token,
-      options: PutByPartOptions(key: 'test_for_put_parts.mp4', partSize: 1),
+      options: PutByPartOptions(
+        key: 'test_for_put_parts.mp4',
+        partSize: 1,
+        controller: putController,
+      ),
     );
     expect(response, isA<PutResponse>());
     expect(_sent / _total, equals(1));
   }, skip: !isSensitiveDataDefined);
 }
 
-class HttpAdapterTest extends HttpClientAdapter {
+class HttpAdapterTestWith612 extends HttpClientAdapter {
   /// 记录 CompletePartsTask 被创建的次数
   /// 第一次我们拦截并返回 612，第二次不拦截
   bool completePartsTaskResponse612 = false;

--- a/base/test/storage_test.dart
+++ b/base/test/storage_test.dart
@@ -16,11 +16,7 @@ void main() {
   final storage = Storage();
 
   test('put should works well.', () async {
-    final putController = storage.putFile(
-      File('test_resource/test_for_put.txt'),
-      token,
-      options: PutOptions(key: 'test_for_put.txt'),
-    );
+    final putController = PutController();
     int _sent, _total;
     putController.addProgressListener((sent, total) {
       _sent = sent;
@@ -28,7 +24,11 @@ void main() {
     });
     final statusList = <RequestTaskStatus>[];
     putController.addStatusListener(statusList.add);
-    final response = await putController.future;
+    final response = await storage.putFile(
+      File('test_resource/test_for_put.txt'),
+      token,
+      options: PutOptions(key: 'test_for_put.txt', controller: putController),
+    );
     expect(statusList[0], RequestTaskStatus.Request);
     expect(statusList[1], RequestTaskStatus.Done);
     expect(_sent / _total, 1);
@@ -50,81 +50,89 @@ void main() {
       ),
     );
 
-    final putController = storage.putFile(
+    final response = await storage.putFile(
       File('test_resource/test_for_put.txt'),
       token,
       options: PutOptions(key: 'test_for_put.txt'),
     );
 
-    final response = await putController.future;
-
     expect(response.rawData, {'ext': '.txt'});
   }, skip: !isSensitiveDataDefined);
 
   test('putFileBySingle should works well.', () async {
-    final putController = storage.putFileBySingle(
-      File('test_resource/test_for_put.txt'),
-      token,
-      options: PutBySingleOptions(key: 'test_for_put.txt'),
-    );
+    final putController = PutController();
     final statusList = <RequestTaskStatus>[];
     putController.addStatusListener(statusList.add);
-    final response = await putController.future;
+    final response = await storage.putFileBySingle(
+      File('test_resource/test_for_put.txt'),
+      token,
+      options: PutBySingleOptions(
+        key: 'test_for_put.txt',
+        controller: putController,
+      ),
+    );
     expect(statusList[0], RequestTaskStatus.Request);
     expect(statusList[1], RequestTaskStatus.Done);
     expect(response.key, 'test_for_put.txt');
   }, skip: !isSensitiveDataDefined);
 
   test('putFileBySingle can be canceled.', () async {
-    final putController = storage.putFileBySingle(
-      File('test_resource/test_for_put.txt'),
-      token,
-      options: PutBySingleOptions(key: 'test_for_put.txt'),
-    );
+    final putController = PutController();
 
     final statusList = <RequestTaskStatus>[];
     putController.addStatusListener(statusList.add);
-
+    final future = storage.putFileBySingle(
+      File('test_resource/test_for_put.txt'),
+      token,
+      options: PutBySingleOptions(
+          key: 'test_for_put.txt', controller: putController),
+    );
     try {
       Future.delayed(Duration(milliseconds: 1), putController.cancel);
-      final response = await putController.future;
-      expect(response.key, 'test_for_put.txt');
+      await future;
     } catch (error) {
       expect(error, isA<DioError>());
       expect((error as DioError).type, DioErrorType.CANCEL);
     }
-    expect(putController.future, throwsA(TypeMatcher<DioError>()));
+    expect(future, throwsA(TypeMatcher<DioError>()));
     expect(statusList[0], RequestTaskStatus.Request);
     expect(statusList[1], RequestTaskStatus.Cancel);
   }, skip: !isSensitiveDataDefined);
 
   test('listenProgress on putFileBySingle method should works well.', () async {
-    final putTask = storage.putFileBySingle(
-      File('test_resource/test_for_put.txt'),
-      token,
-      options: PutBySingleOptions(key: 'test_for_put.txt'),
-    );
+    final putController = PutController();
 
     int _sent, _total;
-    putTask.addProgressListener((sent, total) {
+    putController.addProgressListener((sent, total) {
       _sent = sent;
       _total = total;
     });
 
-    final response = await putTask.future;
+    final response = await storage.putFileBySingle(
+      File('test_resource/test_for_put.txt'),
+      token,
+      options: PutBySingleOptions(
+        key: 'test_for_put.txt',
+        controller: putController,
+      ),
+    );
     expect(response.key, 'test_for_put.txt');
     expect(_sent / _total, equals(1));
   }, skip: !isSensitiveDataDefined);
 
   test('putFileByPart should works well.', () async {
-    final putController = storage.putFileByPart(
-      File('test_resource/test_for_put_parts.mp4'),
-      token,
-      options: PutByPartOptions(key: 'test_for_put_parts.mp4', partSize: 1),
-    );
+    final putController = PutController();
     final statusList = <RequestTaskStatus>[];
     putController.addStatusListener(statusList.add);
-    final response = await putController.future;
+    final response = await storage.putFileByPart(
+      File('test_resource/test_for_put_parts.mp4'),
+      token,
+      options: PutByPartOptions(
+        key: 'test_for_put_parts.mp4',
+        partSize: 1,
+        controller: putController,
+      ),
+    );
     expect(response, isA<PutResponse>());
     expect(statusList[0], RequestTaskStatus.Request);
     expect(statusList[1], RequestTaskStatus.Done);
@@ -134,13 +142,11 @@ void main() {
     final httpAdapterTest = HttpAdapterTest();
     final storage = Storage(config: Config(httpClientAdapter: httpAdapterTest));
 
-    final putController = storage.putFileByPart(
+    final response = await storage.putFileByPart(
       File('test_resource/test_for_put_parts.mp4'),
       token,
       options: PutByPartOptions(key: 'test_for_put_parts.mp4', partSize: 1),
     );
-
-    final response = await putController.future;
 
     /// httpAdapterTest 应该会触发一次 612 response
     expect(httpAdapterTest.completePartsTaskResponse612, true);
@@ -149,50 +155,62 @@ void main() {
 
   test('putFileByPart can be canceled.', () async {
     final storage = Storage(config: Config(hostProvider: HostProviderTest()));
-    final putController = storage.putFileByPart(
-      File('test_resource/test_for_put_parts.mp4'),
-      token,
-      options: PutByPartOptions(key: 'test_for_put_parts.mp4', partSize: 1),
-    );
+    final putController = PutController();
     final statusList = <RequestTaskStatus>[];
     putController.addStatusListener(statusList.add);
-    Future.delayed(Duration(milliseconds: 1), putController.cancel);
+    Future.delayed(Duration(milliseconds: 10), putController.cancel);
+    final future = storage.putFileByPart(
+      File('test_resource/test_for_put_parts.mp4'),
+      token,
+      options: PutByPartOptions(
+        key: 'test_for_put_parts.mp4',
+        partSize: 1,
+        controller: putController,
+      ),
+    );
     try {
-      await putController.future;
+      await future;
     } catch (error) {
       expect((error as DioError).type, DioErrorType.CANCEL);
     }
-    expect(putController.future, throwsA(TypeMatcher<DioError>()));
+    expect(future, throwsA(TypeMatcher<DioError>()));
     expect(statusList[0], RequestTaskStatus.Request);
     expect(statusList[1], RequestTaskStatus.Cancel);
   }, skip: !isSensitiveDataDefined);
 
   test('putFileByPart can be resumed.', () async {
     final storage = Storage(config: Config(hostProvider: HostProviderTest()));
-    final putController = storage.putFileByPart(
-      File('test_resource/test_for_put_parts.mp4'),
-      token,
-      options: PutByPartOptions(key: 'test_for_put_parts.mp4', partSize: 1),
-    );
+    final putController = PutController();
 
     Future.delayed(Duration(milliseconds: 1), putController.cancel);
+    final future = storage.putFileByPart(
+      File('test_resource/test_for_put_parts.mp4'),
+      token,
+      options: PutByPartOptions(
+        key: 'test_for_put_parts.mp4',
+        partSize: 1,
+        controller: putController,
+      ),
+    );
 
     try {
-      await putController.future;
+      await future;
     } catch (error) {
       expect(error, isA<DioError>());
       expect((error as DioError).type, DioErrorType.CANCEL);
     }
 
-    expect(putController.future, throwsA(TypeMatcher<DioError>()));
+    expect(future, throwsA(TypeMatcher<DioError>()));
 
-    final response = await storage
-        .putFileByPart(
-          File('test_resource/test_for_put_parts.mp4'),
-          token,
-          options: PutByPartOptions(key: 'test_for_put_parts.mp4', partSize: 1),
-        )
-        .future;
+    final response = await storage.putFileByPart(
+      File('test_resource/test_for_put_parts.mp4'),
+      token,
+      options: PutByPartOptions(
+        key: 'test_for_put_parts.mp4',
+        partSize: 1,
+        controller: putController,
+      ),
+    );
 
     expect(response, isA<PutResponse>());
   }, skip: !isSensitiveDataDefined);
@@ -215,17 +233,19 @@ void main() {
       key: key,
     );
 
-    storage.taskManager.addTask(task);
+    storage.taskManager.addRequestTask(task);
 
     await task.future;
 
-    final putController = storage.putFileByPart(
-      file,
-      token,
-      options: PutByPartOptions(key: key, partSize: 1),
-    );
+    final putController = PutController();
 
     Future.delayed(Duration(milliseconds: 1), putController.cancel);
+    final future = storage.putFileByPart(
+      file,
+      token,
+      options:
+          PutByPartOptions(key: key, partSize: 1, controller: putController),
+    );
 
     /// 这个时候应该只缓存了初始化的缓存信息
     expect(cacheProvider.value.length, 1);
@@ -240,19 +260,17 @@ void main() {
     expect(cacheProvider.getItem(cacheKey), isA<String>());
 
     try {
-      await putController.future;
+      await future;
     } catch (error) {
       expect(error, isA<DioError>());
       expect((error as DioError).type, DioErrorType.CANCEL);
     }
 
-    final response = await storage
-        .putFileByPart(
-          file,
-          token,
-          options: PutByPartOptions(key: key, partSize: 1),
-        )
-        .future;
+    final response = await storage.putFileByPart(
+      file,
+      token,
+      options: PutByPartOptions(key: key, partSize: 1),
+    );
 
     expect(response, isA<PutResponse>());
 
@@ -261,11 +279,7 @@ void main() {
   }, skip: !isSensitiveDataDefined);
 
   test('listenProgress on putFileByPart method should works well.', () async {
-    final putController = storage.putFileByPart(
-      File('test_resource/test_for_put_parts.mp4'),
-      token,
-      options: PutByPartOptions(key: 'test_for_put_parts.mp4', partSize: 1),
-    );
+    final putController = PutController();
 
     int _sent, _total;
     putController.addProgressListener((sent, total) {
@@ -273,7 +287,11 @@ void main() {
       _total = total;
     });
 
-    final response = await putController.future;
+    final response = await storage.putFileByPart(
+      File('test_resource/test_for_put_parts.mp4'),
+      token,
+      options: PutByPartOptions(key: 'test_for_put_parts.mp4', partSize: 1),
+    );
     expect(response, isA<PutResponse>());
     expect(_sent / _total, equals(1));
   }, skip: !isSensitiveDataDefined);


### PR DESCRIPTION
在 Dart 和 Flutter 里面大家对 controller 的用法和我们在 js 里面得不太一样。Flutter 这边习惯把 controller 传进去，而不是返回一个 controller。好处就是不会打乱正常的使用方式的同时，还可以支持 controll。现在调整为如下用法:

```dart
/// 之前
PutController putController = storage.putFile(key, token);
final response = await putController.future;

/// 现在
final putController = PutController();
final response = await storage.putFile(key, token, options: PutOptions(controller: putController));
```