### PR TITLE
增加重试和冻结逻辑

### DIFF
--- a/base/lib/src/storage/config/config.dart
+++ b/base/lib/src/storage/config/config.dart
@@ -1,6 +1,7 @@
 import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
 import 'package:meta/meta.dart';
+import 'package:qiniu_sdk_base/src/storage/error/error.dart';
 
 part 'protocol.dart';
 part 'host.dart';
@@ -11,10 +12,16 @@ class Config {
   final CacheProvider cacheProvider;
   final HttpClientAdapter httpClientAdapter;
 
+  /// 重试次数
+  ///
+  /// 各种网络请求失败的重试次数
+  final int retryLimit;
+
   Config({
     HostProvider hostProvider,
     CacheProvider cacheProvider,
     HttpClientAdapter httpClientAdapter,
+    this.retryLimit = 3,
   })  : hostProvider = hostProvider ?? DefaultHostProvider(),
         cacheProvider = cacheProvider ?? DefaultCacheProvider(),
         httpClientAdapter = httpClientAdapter ?? DefaultHttpClientAdapter();

--- a/base/lib/src/storage/config/host.dart
+++ b/base/lib/src/storage/config/host.dart
@@ -5,27 +5,128 @@ abstract class HostProvider {
     @required String accessKey,
     @required String bucket,
   });
+
+  bool isFrozen(String host);
+
+  void freezeHost(String host);
 }
 
 class DefaultHostProvider extends HostProvider {
-  final http = Dio();
+  final protocol = Protocol.Https.value;
+
+  final _http = Dio();
+  // 缓存的上传区域
+  final _stashedUpDomains = <_Domain>[];
+  // 缓存之前的 bucket 用于判断是否需要走缓存
+  String _prevBucket;
+  // 冻结的上传区域
+  final List<_Domain> _frozenUpDomains = [];
 
   @override
   Future<String> getUpHost({
     @required String accessKey,
     @required String bucket,
   }) async {
-    final protocol = Protocol.Https.value;
+    // 解冻需要被解冻的 host
+    _frozenUpDomains.removeWhere((domain) => !domain.isFrozen());
 
-    final url = protocol +
-        '://api.qiniu.com/v2/query?ak=' +
-        accessKey +
-        '&bucket=' +
-        bucket;
+    var _upDomains = <_Domain>[];
+    if (bucket == _prevBucket && _stashedUpDomains.isNotEmpty) {
+      _upDomains.addAll(_stashedUpDomains);
+    } else {
+      final url =
+          '$protocol://api.qiniu.com/v4/query?ak=$accessKey&bucket=$bucket';
 
-    final res = await http.get<Map>(url);
-    final host = res.data['up']['acc']['main'][0] as String;
+      final res = await _http.get<Map>(url);
+      final hosts = res.data['hosts']
+          .map((dynamic json) => _Host.fromJson(json as Map))
+          .cast<_Host>()
+          .toList() as List<_Host>;
 
-    return protocol + '://' + host;
+      for (var host in hosts) {
+        final domainList = host.up['domains'].cast<String>() as List<String>;
+        final domains = domainList.map((domain) => _Domain(domain));
+        _upDomains.addAll(domains);
+      }
+
+      _prevBucket = bucket;
+    }
+
+    // 每次都从头遍历一遍，bucket 所在的区域的 host 总是会排在最前面
+    // TODO 按照客户端所在区域选择更适合 ta 的 host
+    for (var index = 0; index < _upDomains.length; index++) {
+      final availableDomain = _upDomains.elementAt(index);
+      // 检查看起来可用的 host 是否之前被冻结过
+      final fronzenUpDomain = _frozenUpDomains.firstWhere(
+        (domain) => domain.isFrozen() && domain.value == availableDomain.value,
+        orElse: () => null,
+      );
+      if (fronzenUpDomain == null) {
+        return protocol + '://' + availableDomain.value;
+      }
+    }
+    // 全部被冻结，几乎不存在的情况
+    throw StorageError(type: StorageErrorType.UNKNOWN, message: '没有可用的服务器');
   }
+
+  @override
+  bool isFrozen(String host) {
+    final uri = Uri.parse(host);
+    final frozenDomain = _frozenUpDomains
+        .firstWhere((domain) => domain.value == uri.host, orElse: () => null);
+    return frozenDomain != null;
+  }
+
+  @override
+  void freezeHost(String host) {
+    // http://example.org
+    // scheme: http
+    // host: example.org
+    final uri = Uri.parse(host);
+    _frozenUpDomains.add(_Domain(uri.host)..freeze());
+  }
+
+  // @override
+  // void unfreezeHost(String host) {
+  //   final uri = Uri.parse(host);
+  //   final domain = _frozenUpDomains
+  //       .firstWhere((domain) => domain.value == uri.host, orElse: () => null);
+
+  //   if (domain != null) {
+  //     _frozenUpDomains.remove(domain);
+  //   }
+  // }
+}
+
+class _Host {
+  String region;
+  int ttl;
+  // domains: []
+  Map<String, dynamic> up;
+
+  _Host({this.region, this.ttl, this.up});
+
+  factory _Host.fromJson(Map json) {
+    return _Host(
+      region: json['region'] as String,
+      ttl: json['ttl'] as int,
+      up: json['up'] as Map<String, dynamic>,
+    );
+  }
+}
+
+class _Domain {
+  int frozenTime = 0;
+  final _lockTime = 1000 * 60 * 10;
+
+  bool isFrozen() {
+    return frozenTime + _lockTime > DateTime.now().millisecond;
+  }
+
+  void freeze() {
+    frozenTime = DateTime.now().millisecond;
+  }
+
+  String value;
+  _Domain(this.value);
 }

--- a/base/lib/src/storage/error/error.dart
+++ b/base/lib/src/storage/error/error.dart
@@ -24,6 +24,7 @@ enum StorageErrorType {
 }
 
 class StorageError extends QiniuError {
+  /// [type] 不是 [StorageErrorType.RESPONSE] 的时候为 null
   final int code;
   final StorageErrorType type;
 
@@ -31,7 +32,7 @@ class StorageError extends QiniuError {
 
   @override
   String toString() {
-    var msg = 'StorageRequestException [$type, $code]: $message';
+    var msg = 'StorageError [$type, $code]: $message';
     msg += '\n${StackTrace.current}';
     return msg;
   }

--- a/base/lib/src/storage/error/error.dart
+++ b/base/lib/src/storage/error/error.dart
@@ -30,6 +30,14 @@ class StorageError extends QiniuError {
 
   StorageError({this.type, this.code, String message}) : super(message);
 
+  factory StorageError.fromDioError(DioError error) {
+    return StorageError(
+      type: _mapDioErrorType(error.type),
+      code: error.response?.statusCode,
+      message: error.response?.data.toString(),
+    );
+  }
+
   @override
   String toString() {
     var msg = 'StorageError [$type, $code]: $message';
@@ -38,7 +46,7 @@ class StorageError extends QiniuError {
   }
 }
 
-StorageErrorType mapDioErrorType(DioErrorType type) {
+StorageErrorType _mapDioErrorType(DioErrorType type) {
   switch (type) {
     case DioErrorType.CONNECT_TIMEOUT:
       return StorageErrorType.CONNECT_TIMEOUT;

--- a/base/lib/src/storage/methods/put/by_part/complete_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/complete_parts_task.dart
@@ -6,12 +6,15 @@ class CompletePartsTask extends RequestTask<PutResponse> {
   final String uploadId;
   final List<Part> parts;
   final String key;
+  final VoidCallback onRestart;
+
   TokenInfo _tokenInfo;
 
   CompletePartsTask({
     @required this.token,
     @required this.uploadId,
     @required this.parts,
+    @required this.onRestart,
     this.key,
     RequestTaskController controller,
   }) : super(controller: controller);
@@ -23,11 +26,17 @@ class CompletePartsTask extends RequestTask<PutResponse> {
   }
 
   @override
+  void postRestart() {
+    onRestart();
+    super.postStart();
+  }
+
+  @override
   Future<PutResponse> createTask() async {
     final bucket = _tokenInfo.putPolicy.getBucket();
 
     final host = await config.hostProvider.getUpHost(
-      bucket: _tokenInfo.putPolicy.getBucket(),
+      bucket: bucket,
       accessKey: _tokenInfo.accessKey,
     );
     final headers = <String, dynamic>{'Authorization': 'UpToken $token'};

--- a/base/lib/src/storage/methods/put/by_part/complete_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/complete_parts_task.dart
@@ -3,24 +3,33 @@ part of 'put_parts_task.dart';
 /// 创建文件，把切片信息合成为一个文件
 class CompletePartsTask extends RequestTask<PutResponse> {
   final String token;
-  final String bucket;
   final String uploadId;
   final List<Part> parts;
-  final String host;
   final String key;
+  TokenInfo _tokenInfo;
 
   CompletePartsTask({
     @required this.token,
-    @required this.bucket,
     @required this.uploadId,
     @required this.parts,
-    @required this.host,
     this.key,
     RequestTaskController controller,
   }) : super(controller: controller);
 
   @override
+  void preStart() {
+    _tokenInfo = Auth.parseUpToken(token);
+    super.preStart();
+  }
+
+  @override
   Future<PutResponse> createTask() async {
+    final bucket = _tokenInfo.putPolicy.getBucket();
+
+    final host = await config.hostProvider.getUpHost(
+      bucket: _tokenInfo.putPolicy.getBucket(),
+      accessKey: _tokenInfo.accessKey,
+    );
     final headers = <String, dynamic>{'Authorization': 'UpToken $token'};
     final encodedKey = key != null ? base64Url.encode(utf8.encode(key)) : '~';
     final paramUrl =

--- a/base/lib/src/storage/methods/put/by_part/init_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/init_parts_task.dart
@@ -30,6 +30,7 @@ class InitPartsTask extends RequestTask<InitParts> with CacheMixin<InitParts> {
   final File file;
   final String token;
   final String key;
+  final VoidCallback onRestart;
 
   @override
   String _cacheKey;
@@ -38,6 +39,7 @@ class InitPartsTask extends RequestTask<InitParts> with CacheMixin<InitParts> {
   InitPartsTask({
     @required this.file,
     @required this.token,
+    @required this.onRestart,
     this.key,
     RequestTaskController controller,
   }) : super(controller: controller);
@@ -54,6 +56,12 @@ class InitPartsTask extends RequestTask<InitParts> with CacheMixin<InitParts> {
   }
 
   @override
+  void postRestart() {
+    onRestart();
+    super.postStart();
+  }
+
+  @override
   Future<InitParts> createTask() async {
     final headers = {'Authorization': 'UpToken $token'};
 
@@ -66,7 +74,7 @@ class InitPartsTask extends RequestTask<InitParts> with CacheMixin<InitParts> {
     final bucket = _tokenInfo.putPolicy.getBucket();
 
     final host = await config.hostProvider.getUpHost(
-      bucket: _tokenInfo.putPolicy.getBucket(),
+      bucket: bucket,
       accessKey: _tokenInfo.accessKey,
     );
 

--- a/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
@@ -133,6 +133,8 @@ class PutByPartTask extends RequestTask<PutResponse> {
       token: token,
       key: key,
       controller: _controller,
+      onRestart: () =>
+          controller.notifyStatusListeners(RequestTaskStatus.Request),
     );
 
     /// 假的 1 byte，说明任务已经开始且不是 0%
@@ -154,6 +156,8 @@ class PutByPartTask extends RequestTask<PutResponse> {
       maxPartsRequestNumber: maxPartsRequestNumber,
       key: key,
       controller: _controller,
+      onRestart: () =>
+          controller.notifyStatusListeners(RequestTaskStatus.Request),
     );
 
     _controller.addProgressListener((sent, total) {
@@ -178,6 +182,8 @@ class PutByPartTask extends RequestTask<PutResponse> {
       parts: parts,
       key: key,
       controller: _controller,
+      onRestart: () =>
+          controller.notifyStatusListeners(RequestTaskStatus.Request),
     );
 
     manager.addRequestTask(task);

--- a/base/lib/src/storage/methods/put/by_single/put_by_single_task.dart
+++ b/base/lib/src/storage/methods/put/by_single/put_by_single_task.dart
@@ -19,6 +19,8 @@ class PutBySingleTask extends RequestTask<PutResponse> {
   /// 如果不传则后端自动生成
   final String key;
 
+  TokenInfo _tokenInfo;
+
   PutBySingleTask({
     @required this.file,
     @required this.token,
@@ -29,10 +31,13 @@ class PutBySingleTask extends RequestTask<PutResponse> {
         super(controller: controller);
 
   @override
-  Future<PutResponse> createTask() async {
-    final tokenInfo = Auth.parseUpToken(token);
-    final putPolicy = tokenInfo.putPolicy;
+  void preStart() {
+    _tokenInfo = Auth.parseUpToken(token);
+    super.preStart();
+  }
 
+  @override
+  Future<PutResponse> createTask() async {
     final formData = FormData.fromMap(<String, dynamic>{
       'file': await MultipartFile.fromFile(file.path),
       'token': token,
@@ -40,8 +45,8 @@ class PutBySingleTask extends RequestTask<PutResponse> {
     });
 
     final host = await config.hostProvider.getUpHost(
-      accessKey: tokenInfo.accessKey,
-      bucket: putPolicy.getBucket(),
+      accessKey: _tokenInfo.accessKey,
+      bucket: _tokenInfo.putPolicy.getBucket(),
     );
 
     final response = await client.post<Map<String, dynamic>>(

--- a/base/lib/src/storage/storage.dart
+++ b/base/lib/src/storage/storage.dart
@@ -81,7 +81,7 @@ class Storage {
       hostProvider: config.hostProvider,
     );
 
-    taskManager.addTask(task);
+    taskManager.addRequestTask(task);
 
     return task.future;
   }

--- a/base/lib/src/storage/task/request_task.dart
+++ b/base/lib/src/storage/task/request_task.dart
@@ -15,6 +15,9 @@ abstract class RequestTask<T> extends Task<T> {
   Config config;
   RequestTaskController controller;
 
+  /// 重试次数
+  int _retryCount = 0;
+
   RequestTask({this.controller});
 
   @override
@@ -43,30 +46,109 @@ abstract class RequestTask<T> extends Task<T> {
 
   /// [createTask] 被取消后触发
   @mustCallSuper
-  void postCancel(DioError error) {
+  void postCancel(StorageError error) {
     controller?.notifyStatusListeners(RequestTaskStatus.Cancel);
   }
 
   @override
   @mustCallSuper
-  void postError(Object error) {
-    // 通知状态
-    if (error is DioError && error.type == DioErrorType.CANCEL) {
-      postCancel(error);
-    } else {
-      controller?.notifyStatusListeners(RequestTaskStatus.Error);
+  void postError(Object error) async {
+    // 重试和冻结
+    if (error is DioError) {
+      if (!canConnectToHost(error)) {
+        // host 连不上，判断是否 host 不可用造成的, 比如 tls error(没做还)
+        if (isHostUnavailable(error)) {
+          config.hostProvider.freezeHost(error.request.path);
+        }
+
+        // 继续尝试当前 host，如果是服务器坏了则切换到其他 host
+        if (_retryCount < config.retryLimit) {
+          _retryCount++;
+          manager.restartTask(this);
+          return;
+        }
+      }
+
+      // 能连上但是服务器不可用，比如 502
+      if (isHostUnavailable(error)) {
+        config.hostProvider.freezeHost(error.request.path);
+
+        // 切换到其他 host
+        if (_retryCount < config.retryLimit) {
+          _retryCount++;
+          manager.restartTask(this);
+          return;
+        }
+      }
+
+      if (error.type != DioErrorType.DEFAULT) {
+        final storageError = StorageError(
+          type: mapDioErrorType(error.type),
+          code: error.response?.statusCode,
+          message: error.response?.data.toString(),
+        );
+
+        // 通知状态
+        if (error.type == DioErrorType.CANCEL) {
+          postCancel(storageError);
+        } else {
+          controller?.notifyStatusListeners(RequestTaskStatus.Error);
+        }
+
+        super.postError(storageError);
+        return;
+      }
+    }
+    // 如果有子任务，错误可能被子任务加工成 StorageError
+    if (error is StorageError) {
+      if (error.type == StorageErrorType.CANCEL) {
+        postCancel(error);
+      } else {
+        controller?.notifyStatusListeners(RequestTaskStatus.Error);
+      }
     }
 
-    // 处理错误
-    if (error is DioError && error.type != DioErrorType.DEFAULT) {
-      final _error = StorageError(
-        type: mapDioErrorType(error.type),
-        code: error.response?.statusCode,
-        message: error.response?.data.toString(),
-      );
-      super.postError(_error);
-    } else {
-      super.postError(error);
+    super.postError(error);
+  }
+
+  // host 是否可以连接上
+  bool canConnectToHost(Object error) {
+    if (error is DioError) {
+      if (error.type == DioErrorType.RESPONSE &&
+          error.response.statusCode > 99) {
+        return true;
+      }
+
+      if (error.type == DioErrorType.CANCEL) {
+        return true;
+      }
     }
+
+    return false;
+  }
+
+  // host 是否不可用
+  bool isHostUnavailable(Object error) {
+    if (error is DioError) {
+      if (error.type == DioErrorType.RESPONSE) {
+        final statusCode = error.response.statusCode;
+        if (statusCode == 502) {
+          return true;
+        }
+        if (statusCode == 503) {
+          return true;
+        }
+        if (statusCode == 504) {
+          return true;
+        }
+        if (statusCode == 599) {
+          return true;
+        }
+      }
+      // ignore: todo
+      // TODO 更详细的信息 SocketException
+    }
+
+    return false;
   }
 }

--- a/base/lib/src/storage/task/request_task.dart
+++ b/base/lib/src/storage/task/request_task.dart
@@ -82,11 +82,7 @@ abstract class RequestTask<T> extends Task<T> {
       }
 
       if (error.type != DioErrorType.DEFAULT) {
-        final storageError = StorageError(
-          type: mapDioErrorType(error.type),
-          code: error.response?.statusCode,
-          message: error.response?.data.toString(),
-        );
+        final storageError = StorageError.fromDioError(error);
 
         // 通知状态
         if (error.type == DioErrorType.CANCEL) {

--- a/base/lib/src/storage/task/task_manager.dart
+++ b/base/lib/src/storage/task/task_manager.dart
@@ -21,11 +21,12 @@ class TaskManager {
   @mustCallSuper
   void addTask(Task task) {
     workingTasks.add(task);
-    task.manager = this;
+    task
+      ..manager = this
+      ..preStart();
 
     /// 把同步的任务改成异步，防止 [RequestTask.addStatusListener] 没有被触发
     Future.delayed(Duration(milliseconds: 0), () {
-      task.preStart();
       task.createTask().then(task.postReceive).catchError(task.postError);
       task.postStart();
     });

--- a/base/test/config_test.dart
+++ b/base/test/config_test.dart
@@ -1,3 +1,4 @@
+import 'package:dotenv/dotenv.dart';
 import 'package:qiniu_sdk_base/src/storage/storage.dart';
 import 'package:qiniu_sdk_base/qiniu_sdk_base.dart';
 import 'package:test/test.dart';
@@ -33,4 +34,21 @@ void main() {
 
     expect(cacheProvider.value.length, 0);
   });
+
+  test('freeze mechanism should works well with DefaultHostProvider.',
+      () async {
+    final config = Config();
+    final hostA = await config.hostProvider.getUpHost(
+      accessKey: env['QINIU_DART_SDK_ACCESS_KEY'],
+      bucket: env['QINIU_DART_SDK_TOKEN_SCOPE'],
+    );
+    config.hostProvider.freezeHost(hostA);
+    final hostB = await config.hostProvider.getUpHost(
+      accessKey: env['QINIU_DART_SDK_ACCESS_KEY'],
+      bucket: env['QINIU_DART_SDK_TOKEN_SCOPE'],
+    );
+
+    // getUpHost 会收集所有地区的 host 并以此吐出来，不用担心会少于两个
+    expect(hostA == hostB, false);
+  }, skip: !isSensitiveDataDefined);
 }

--- a/base/test/retry_test.dart
+++ b/base/test/retry_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:dio/adapter.dart';
+import 'package:dio/dio.dart';
+import 'package:qiniu_sdk_base/qiniu_sdk_base.dart';
+
+import 'config.dart';
+
+void main() {
+  configEnv();
+
+  test('retry mechanism should works well with putBySingle.', () async {
+    final config = Config(
+      hostProvider: HostProviderTest(),
+      httpClientAdapter: HttpAdapterTestWith502(),
+    );
+    final storage = Storage(config: config);
+    final putController = PutController();
+    final statusList = <RequestTaskStatus>[];
+    putController.addStatusListener(statusList.add);
+    final response = await storage.putFileBySingle(
+      File('test_resource/test_for_put.txt'),
+      token,
+      options: PutBySingleOptions(
+        key: 'test_for_put.txt',
+        controller: putController,
+      ),
+    );
+    expect(statusList[0], RequestTaskStatus.Init);
+    expect(statusList[1], RequestTaskStatus.Request);
+    // 重试了 1 次
+    expect(statusList[2], RequestTaskStatus.Request);
+    expect(statusList[3], RequestTaskStatus.Success);
+    expect(response.key, 'test_for_put.txt');
+  }, skip: !isSensitiveDataDefined);
+
+  test('retry mechanism should works well with putByPart.', () async {
+    final config = Config(
+      hostProvider: HostProviderTest(),
+      httpClientAdapter: HttpAdapterTestWith502(),
+    );
+    final storage = Storage(config: config);
+    final putController = PutController();
+    final statusList = <RequestTaskStatus>[];
+    int _sent, _total;
+    putController
+      ..addStatusListener(statusList.add)
+      ..addProgressListener((sent, total) {
+        _sent = sent;
+        _total = total;
+      });
+    final file = File('test_resource/test_for_put_parts.mp4');
+    final response = await storage.putFileByPart(
+      file,
+      token,
+      options: PutByPartOptions(
+        key: 'test_for_put_parts.mp4',
+        partSize: 1,
+        controller: putController,
+      ),
+    );
+    expect(response, isA<PutResponse>());
+
+    /// 分片上传会给 _sent _total + 1
+    expect(_sent - 1, file.lengthSync());
+    expect(_total - 1, file.lengthSync());
+    expect(_sent / _total, 1);
+    expect(statusList[0], RequestTaskStatus.Init);
+    expect(statusList[1], RequestTaskStatus.Request);
+    // 分片上传任务本身不会重试，子任务负责重试，所以不会有第二个 Request 状态
+    expect(statusList[2], RequestTaskStatus.Success);
+  }, skip: !isSensitiveDataDefined);
+}
+
+// 502 会触发服务不可用逻辑导致该 host 被冻结，并重试其他 host
+class HttpAdapterTestWith502 extends HttpClientAdapter {
+  final DefaultHttpClientAdapter _adapter = DefaultHttpClientAdapter();
+  @override
+  void close({bool force = false}) {
+    _adapter.close(force: force);
+  }
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options,
+      Stream<List<int>> requestStream, Future cancelFuture) async {
+    if (options.path.contains('test.com') && options.method == 'POST') {
+      return ResponseBody.fromString('', 502);
+    }
+    return _adapter.fetch(options, requestStream, cancelFuture);
+  }
+}
+
+class HostProviderTest extends HostProvider {
+  final _hostProvider = DefaultHostProvider();
+  @override
+  void freezeHost(String host) {
+    _hostProvider.freezeHost(host);
+  }
+
+  @override
+  Future<String> getUpHost({String accessKey, String bucket}) async {
+    if (isFrozen('https://test.com')) {
+      return _hostProvider.getUpHost(accessKey: accessKey, bucket: bucket);
+    }
+    return 'https://test.com';
+  }
+
+  @override
+  bool isFrozen(String host) {
+    return _hostProvider.isFrozen(host);
+  }
+}

--- a/base/test/retry_test.dart
+++ b/base/test/retry_test.dart
@@ -67,8 +67,9 @@ void main() {
     expect(_sent / _total, 1);
     expect(statusList[0], RequestTaskStatus.Init);
     expect(statusList[1], RequestTaskStatus.Request);
-    // 分片上传任务本身不会重试，子任务负责重试，所以不会有第二个 Request 状态
-    expect(statusList[2], RequestTaskStatus.Success);
+    // 重试了一次
+    expect(statusList[2], RequestTaskStatus.Request);
+    expect(statusList[3], RequestTaskStatus.Success);
   }, skip: !isSensitiveDataDefined);
 }
 

--- a/base/test/storage_test.dart
+++ b/base/test/storage_test.dart
@@ -245,19 +245,9 @@ void main() {
     final file = File('test_resource/test_for_put_parts.mp4');
     final key = 'test_for_put_parts.mp4';
 
-    final tokenInfo = Auth.parseUpToken(token);
-    final putPolicy = tokenInfo.putPolicy;
-
     /// 手动初始化一个初始化文件的任务，确定分片上传的第一步会被缓存
     final task = InitPartsTask(
       token: token,
-      host: await config.hostProvider.getUpHost(
-        accessKey: tokenInfo.accessKey,
-        bucket: putPolicy.getBucket(),
-      ),
-
-      /// TOKEN_SCOPE 暂时只保存了 bucket 信息
-      bucket: env['QINIU_DART_SDK_TOKEN_SCOPE'],
       file: file,
       key: key,
     );
@@ -361,5 +351,13 @@ class HostProviderTest extends HostProvider {
     @required String bucket,
   }) async {
     return 'https://upload-z2.qiniup.com';
+  }
+
+  @override
+  void freezeHost(String host) {}
+
+  @override
+  bool isFrozen(String host) {
+    return false;
   }
 }

--- a/base/test/storage_test.dart
+++ b/base/test/storage_test.dart
@@ -247,10 +247,7 @@ void main() {
 
     /// 手动初始化一个初始化文件的任务，确定分片上传的第一步会被缓存
     final task = InitPartsTask(
-      token: token,
-      file: file,
-      key: key,
-    );
+        token: token, file: file, key: key, onRestart: () => null);
 
     storage.taskManager.addRequestTask(task);
 


### PR DESCRIPTION
移动端的 sdk 弱网环境比较多，重试被要求作为硬标准做进去，所以新增了重试机制

+ 如果是连接问题导致的报错则重试最多 3 次(可配置)
+ 如果是服务不可用导致的报错则冻结该 host 10 分钟(默认配置), 并尝试其他 host
