### PR TITLE
修复取消后无法上传的问题

### DIFF
--- a/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
@@ -65,8 +65,7 @@ class PutByPartTask extends RequestTask<PutResponse> {
   void preStart() {
     // 处理相同任务
     final sameTaskExsist = manager.getTasks().firstWhere(
-          (element) =>
-              element != this && element is PutByPartTask && isEquals(element),
+          (element) => element is PutByPartTask && isEquals(element),
           orElse: () => null,
         );
 

--- a/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
@@ -85,7 +85,8 @@ class PutByPartTask extends RequestTask<PutResponse> {
 
     // 处理相同任务
     final sameTaskExsist = manager.getTasks().firstWhere(
-          (element) => element is PutByPartTask && isEquals(element),
+          (element) =>
+              element != this && element is PutByPartTask && isEquals(element),
           orElse: () => null,
         );
 

--- a/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
@@ -69,10 +69,7 @@ class PutByPartTask extends RequestTask<PutResponse> {
           orElse: () => null,
         );
 
-    final initPartsCache = config.cacheProvider
-        .getItem(InitPartsTask.getCacheKey(file.path, file.lengthSync(), key));
-
-    if (initPartsCache != null && sameTaskExsist != null) {
+    if (sameTaskExsist != null) {
       throw StorageError(
         type: StorageErrorType.IN_PROGRESS,
         message: '$file 已在上传队列中',

--- a/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
@@ -63,11 +63,6 @@ class PutByPartTask extends RequestTask<PutResponse> {
 
   @override
   void preStart() {
-    // controller 被取消后取消当前运行的子任务
-    controller?.cancelToken?.whenCancel?.then((_) {
-      _currentWorkingTaskController?.cancel();
-    });
-
     // 处理相同任务
     final sameTaskExsist = manager.getTasks().firstWhere(
           (element) =>
@@ -84,6 +79,11 @@ class PutByPartTask extends RequestTask<PutResponse> {
         message: '$file 已在上传队列中',
       );
     }
+
+    // controller 被取消后取消当前运行的子任务
+    controller?.cancelToken?.whenCancel?.then((_) {
+      _currentWorkingTaskController?.cancel();
+    });
     super.preStart();
   }
 

--- a/base/lib/src/storage/task/request_task.dart
+++ b/base/lib/src/storage/task/request_task.dart
@@ -23,6 +23,10 @@ abstract class RequestTask<T> extends Task<T> {
   @override
   @mustCallSuper
   void preStart() {
+    // 如果已经取消了，直接报错
+    if (controller != null && controller.cancelToken.isCancelled) {
+      throw StorageError(type: StorageErrorType.CANCEL);
+    }
     controller?.notifyStatusListeners(RequestTaskStatus.Init);
     client.httpClientAdapter = config.httpClientAdapter;
     client.interceptors.add(InterceptorsWrapper(onRequest: (options) {

--- a/base/lib/src/storage/task/task_manager.dart
+++ b/base/lib/src/storage/task/task_manager.dart
@@ -19,18 +19,17 @@ class TaskManager {
   /// 被添加的 [task] 会被立即执行 [createTask]
   @mustCallSuper
   void addTask(Task task) {
-    workingTasks.add(task);
     try {
       task
         ..manager = this
         ..preStart();
     } catch (e) {
-      removeTask(task);
       rethrow;
     }
 
-    /// 把同步的任务改成异步，防止 [RequestTask.addStatusListener] 没有被触发
+    // 把同步的任务改成异步，防止 [RequestTask.addStatusListener] 没有被触发
     Future.delayed(Duration(milliseconds: 0), () {
+      workingTasks.add(task);
       task.createTask().then(task.postReceive).catchError(task.postError);
       try {
         task.postStart();

--- a/base/test/storage_test.dart
+++ b/base/test/storage_test.dart
@@ -135,13 +135,15 @@ void main() {
     expect(statusList[0], RequestTaskStatus.Init);
     expect(statusList[1], RequestTaskStatus.Request);
     expect(statusList[2], RequestTaskStatus.Cancel);
-    future = storage.putFileBySingle(
-      file,
-      token,
-      options: PutBySingleOptions(key: key, controller: putController),
-    );
+
     try {
-      await future;
+      // 预期同步发生
+      // ignore: unawaited_futures
+      storage.putFileBySingle(
+        file,
+        token,
+        options: PutBySingleOptions(key: key, controller: putController),
+      );
     } catch (error) {
       // 复用了相同的 controller，所以也会触发取消的错误
       expect(error, isA<StorageError>());
@@ -272,17 +274,18 @@ void main() {
     expect(statusList[1], RequestTaskStatus.Request);
     expect(statusList[2], RequestTaskStatus.Cancel);
 
-    future = storage.putFileByPart(
-      file,
-      token,
-      options: PutByPartOptions(
-        key: key,
-        partSize: 1,
-        controller: putController,
-      ),
-    );
     try {
-      await future;
+      // 预期出错是同步发生的
+      // ignore: unawaited_futures
+      storage.putFileByPart(
+        file,
+        token,
+        options: PutByPartOptions(
+          key: key,
+          partSize: 1,
+          controller: putController,
+        ),
+      );
     } catch (error) {
       // 复用了相同的 controller，所以也会触发取消的错误
       expect(error, isA<StorageError>());

--- a/base/test/storage_test.dart
+++ b/base/test/storage_test.dart
@@ -110,6 +110,8 @@ void main() {
 
   test('putFileBySingle can be cancelled.', () async {
     final putController = PutController();
+    final key = 'test_for_put.txt';
+    final file = File('test_resource/test_for_put.txt');
 
     final statusList = <RequestTaskStatus>[];
     putController.addStatusListener((status) {
@@ -118,11 +120,10 @@ void main() {
         putController.cancel();
       }
     });
-    final future = storage.putFileBySingle(
-      File('test_resource/test_for_put.txt'),
+    var future = storage.putFileBySingle(
+      file,
       token,
-      options: PutBySingleOptions(
-          key: 'test_for_put.txt', controller: putController),
+      options: PutBySingleOptions(key: key, controller: putController),
     );
     try {
       await future;
@@ -134,6 +135,28 @@ void main() {
     expect(statusList[0], RequestTaskStatus.Init);
     expect(statusList[1], RequestTaskStatus.Request);
     expect(statusList[2], RequestTaskStatus.Cancel);
+    future = storage.putFileBySingle(
+      file,
+      token,
+      options: PutBySingleOptions(key: key, controller: putController),
+    );
+    try {
+      await future;
+    } catch (error) {
+      // 复用了相同的 controller，所以也会触发取消的错误
+      expect(error, isA<StorageError>());
+      expect((error as StorageError).type, StorageErrorType.CANCEL);
+    }
+
+    expect(future, throwsA(TypeMatcher<StorageError>()));
+
+    final response = await storage.putFileBySingle(
+      file,
+      token,
+      options: PutBySingleOptions(key: key),
+    );
+
+    expect(response, isA<PutResponse>());
   }, skip: !isSensitiveDataDefined);
 
   test('listenProgress on putFileBySingle method should works well.', () async {
@@ -220,19 +243,21 @@ void main() {
     final putController = PutController();
     final storage = Storage(config: Config(hostProvider: HostProviderTest()));
     final statusList = <RequestTaskStatus>[];
+    final file = File('test_resource/test_for_put_parts.mp4');
+    final key = 'test_for_put_parts.mp4';
     putController
       ..addStatusListener(statusList.add)
       ..addProgressListener((sent, total) {
-        // 开始上传了取消
-        if (sent > 0) {
+        // 开始上传并且 InitPartsTask 设置完缓存后取消
+        if (sent > 1) {
           putController.cancel();
         }
       });
-    final future = storage.putFileByPart(
-      File('test_resource/test_for_put_parts.mp4'),
+    var future = storage.putFileByPart(
+      file,
       token,
       options: PutByPartOptions(
-        key: 'test_for_put_parts.mp4',
+        key: key,
         partSize: 1,
         controller: putController,
       ),
@@ -246,6 +271,32 @@ void main() {
     expect(statusList[0], RequestTaskStatus.Init);
     expect(statusList[1], RequestTaskStatus.Request);
     expect(statusList[2], RequestTaskStatus.Cancel);
+
+    future = storage.putFileByPart(
+      file,
+      token,
+      options: PutByPartOptions(
+        key: key,
+        partSize: 1,
+        controller: putController,
+      ),
+    );
+    try {
+      await future;
+    } catch (error) {
+      // 复用了相同的 controller，所以也会触发取消的错误
+      expect(error, isA<StorageError>());
+      expect((error as StorageError).type, StorageErrorType.CANCEL);
+    }
+
+    expect(future, throwsA(isA<StorageError>()));
+
+    final response = await storage.putFileByPart(
+      file,
+      token,
+      options: PutByPartOptions(key: key, partSize: 1),
+    );
+    expect(response, isA<PutResponse>());
   }, skip: !isSensitiveDataDefined);
 
   test('putFileByPart can be resumed.', () async {


### PR DESCRIPTION
没有在任务队列中排除自己

增加了测试用例
如果传入已经被取消的 controller，则立即报错，而不是执行 `createTask` 的过程中报错
调整了任务被加入队列的时机，现在 `preStart` 执行后加入队列