### PR TITLE
优化分片上传 Progress 的处理方式

### DIFF
--- a/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/put_parts_task.dart
@@ -86,7 +86,7 @@ class PutByPartTask extends RequestTask<PutResponse> {
     final initParts = await initPartsTask.future;
 
     // 初始化任务完成后也告诉外部一个进度
-    controller?.notifyProgressListeners(0.01);
+    controller?.notifyProgressListeners(0.002);
 
     final uploadParts = _createUploadParts(initParts.uploadId);
 

--- a/base/lib/src/storage/methods/put/by_part/upload_parts_task.dart
+++ b/base/lib/src/storage/methods/put/by_part/upload_parts_task.dart
@@ -82,6 +82,10 @@ class UploadPartsTask extends RequestTask<List<Part>> with CacheMixin {
     _totalPartCount = (_fileByteLength / _partByteLength).ceil();
     _cacheKey = getCacheKey(file.path, _fileByteLength, partSize, key);
     recoverUploadedPart();
+    // 子任务 UploadPartTask 从 file 去 open 的话虽然上传精度会颗粒更细但是会导致可能读不出文件的问题
+    // 可能 close 没办法立即关闭 file stream，而延迟 close 了，导致某次 open 的 stream 被立即关闭
+    // 所以读不出内容了
+    // 这里改成这里读取一次，子任务从中读取 bytes
     _raf = file.openSync();
     super.preStart();
   }

--- a/base/test/put/put_by_part_test.dart
+++ b/base/test/put/put_by_part_test.dart
@@ -91,7 +91,7 @@ void main() {
       StorageStatus.Cancel
     ], targetProgressList: [
       0.001,
-      0.01,
+      0.002,
     ]);
 
     try {
@@ -294,7 +294,7 @@ void main() {
     expect(response, isA<PutResponse>());
     pcb
       ..testProcess()
-      ..testStatus(targetProgressList: [0.001, 0.01, 0.99, 1]);
+      ..testStatus(targetProgressList: [0.001, 0.002, 0.99, 1]);
   }, skip: !isSensitiveDataDefined);
 }
 


### PR DESCRIPTION
分片上传的 Progress 改为某个分片上传完成后通知外部进度，注意 Progress 和 SendProgress 的区别。

分片上传创建文件通知外部的进度从 1% 改成 0.1%，避免对后面的进度造成误差，比如 1% 后又从 0.x% 开始