### PR TITLE
更换测试用例里的上传 host

### DIFF
--- a/base/test/config_test.dart
+++ b/base/test/config_test.dart
@@ -18,7 +18,7 @@ void main() {
     );
 
     // 根据传入的 token 的 bucket 对应的区域，需要对应的修改这里
-    expect(hostInToken, 'https://upload-z2.qiniup.com');
+    expect(hostInToken, 'https://upload-na0.qiniup.com');
   }, skip: !isSensitiveDataDefined);
 
   test('DefaultCacheProvider should works well.', () async {

--- a/base/test/put/put_by_part_test.dart
+++ b/base/test/put/put_by_part_test.dart
@@ -352,7 +352,8 @@ class HostProviderTest extends HostProvider {
     @required String accessKey,
     @required String bucket,
   }) async {
-    return 'https://upload-z2.qiniup.com';
+    // token 中 bucket 对应的地区
+    return 'https://upload-na0.qiniup.com';
   }
 
   @override


### PR DESCRIPTION
travis 上传偶尔会超时，我们把测试用的 bucket 换成里北美的，所以用例需要对应的修改

本地测试 ok