### PR TITLE
修复 UserAgent 可能被设置为中文导致报错的问题

### DIFF
--- a/base/CHANGELOG.md
+++ b/base/CHANGELOG.md
@@ -27,3 +27,7 @@
 ## 0.3.2
 
 - 修复 `PutPolicy` 的 forceSaveKey 类型
+
+## 0.3.3
+
+- 修复 UserAgent 可能被设置为中文导致报错的问题

--- a/base/lib/src/storage/task/request_task.dart
+++ b/base/lib/src/storage/task/request_task.dart
@@ -9,12 +9,16 @@ part 'request_task_controller.dart';
 part 'request_task_manager.dart';
 
 String _getUserAgent() {
-  return [
+  final ua = [
     // TODO version
-    'Vendor/qiniu',
-    '${Platform.operatingSystem}/${Platform.operatingSystemVersion}',
-    'Dart/${Platform.version}'
-  ].join(' ');
+    'QiniuDart',
+    Platform.version,
+    Platform.operatingSystem,
+    Platform.operatingSystemVersion,
+    // 字母，数字和 -_.!~*'() 不会被编码
+  ].join('-');
+
+  return Uri.encodeComponent(ua);
 }
 
 abstract class RequestTask<T> extends Task<T> {

--- a/base/pubspec.yaml
+++ b/base/pubspec.yaml
@@ -1,5 +1,5 @@
 name: qiniu_sdk_base
-version: 0.3.2
+version: 0.3.3
 homepage: https://github.com/qiniu/dart-sdk
 description: The sdk basic of Qiniu products
 


### PR DESCRIPTION
客户反馈系统做了国际化，系统版本设置成了中文，我们采集 UA 的时候会收集到中文，导致报错。

规范不允许非 [USASCII](https://datatracker.ietf.org/doc/html/rfc7230#ref-USASCII) 编码，百分比编码是 USASCII 的子集。